### PR TITLE
Gentoo fix for automake 1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,7 @@ AC_CONFIG_FILES([
 AC_SEARCH_LIBS([log], [m])
 AC_SEARCH_LIBS([clock_gettime], [rt])
 AC_SEARCH_LIBS([socket], [socket])
-AC_SEARCH_LIBS([pthread_mutex_lock], [pthread])
+AC_SEARCH_LIBS([pthread_create], [pthread])
 
 AC_SUBST(LIBS)
 


### PR DESCRIPTION
build: drop AM_C_PROTOTYPES.

This macro is deprecated as of Automake 1.12 and can no longer be
used. Most likely is not what was intended to be used.

Make sure to explicitly check for string.h after this change as it was
implied by the macro before.

See http://www.flameeyes.eu/autotools-mythbuster/forwardporting/automake.html
for details.
