### PR TITLE
Avoid unnecessary recompiles due to riting to gitversion.h.

### DIFF
--- a/make-version.sh
+++ b/make-version.sh
@@ -6,7 +6,7 @@ if [ "$GIT" = "" ]; then
 	echo "The 'git' command is not installed."
 	if ! echo $NOGIT | md5sum - | sed 's|-|gitversion.h|' | md5sum -c
 	then
-		echo "/*#define GITVERSION \"\"*/" >gitversion.h
+		echo "$NOGIT" >gitversion.h
 	fi
 	exit 0 
 fi
@@ -15,13 +15,15 @@ if [ ! -d .git ]; then
 	echo "This is not a git release."
 	if ! echo $NOGIT | md5sum - | sed 's|-|gitversion.h|' | md5sum -c
 	then
-		echo "/*#define GITVERSION \"\"*/" >gitversion.h
+		echo "$NOGIT" >gitversion.h
 	fi
 	exit 0
 fi
 
 VERSION=$($GIT describe --always --abbrev=6)
 
-echo "#define GITVERSION \"$VERSION\"" >gitversion.h
-
-
+VGIT="#define GITVERSION \"$VERSION\""
+if ! echo $VGIT | md5sum - | sed 's|-|gitversion.h|' | md5sum -c
+then
+	echo "$VGIT" >gitversion.h
+fi


### PR DESCRIPTION
This will get rid of unnecessary rebuilds everytime "make" is called.
