### PR TITLE
Fix generic, Debian, Ubuntu, and FreeBSD installation instruction

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,23 +1,19 @@
-                             Compiling flowgrind
-                             ===================
-
 Dependencies
-============
-
+------------
 Flowgrind depends on the following tools and libraries:
-- GNU build tools 
-- libxmlrpc-c with curl transport and abyss server 
+  - GNU build tools
+  - libxmlrpc-c with curl transport and abyss server
 
 These libraries as well as their headers and tools need to be installed
 (install appropriate -dev packages too).
 
 The following dependencies are optional and only required for advanced features:
-- libpcap (for automatic dump, optional)
-- libgsl (for advanced traffic generation, optional)
+  - libpcap (for automatic dump, optional)
+  - libgsl (for advanced traffic generation, optional)
+
 
 Building flowgrind
-==================
-
+------------------
 1. a) Extract source tarball OR
    b) Checkout flowgrind from the git repository
       (e.g. git clone git://github.com/flowgrind/flowgrind.git)

--- a/INSTALL.Debian
+++ b/INSTALL.Debian
@@ -1,19 +1,27 @@
-build essentials:
-sudo aptitude install build-essential
+Tested with
+-----------
+Debian 7.0 (Wheezy)
 
-required libraries:
-sudo aptitude install libxmlrpc-c3-dev libcurl4-gnutls-dev
 
-optional libraries:
-sudo aptitude install libpcap0.8-dev
-sudo aptitude install libgsl0-dev
+TARBALL VERSION Installation
+----------------------------
+Install essentials:
+  sudo apt-get install build-essential debhelper cdbs autotools-dev
 
-extract archive:
-tar xjvf flowgrind-*.tar.bz2
-cd flowgrind-*
+Install required xmlrpc-c library:
+  sudo apt-get install libxmlrpc-c3-dev libcurl4-gnutls-dev
 
-build debian package:
-dpkg-buildpackage -rfakeroot -uc -b
+Install optional libGSL and libpcap library if you want to
+use all flowgrind features:
+  sudo apt-get install libpcap-dev
+  sudo apt-get install libgsl0-dev
 
-install resulting packages:
-deb -i *.dpkg
+Extract archive:
+  tar xjvf flowgrind-*.tar.bz2
+  cd flowgrind-*
+
+Build debian package:
+  dpkg-buildpackage -rfakeroot -uc -b
+
+Install resulting packages:
+  cd .. && sudo deb -i *.dpkg

--- a/INSTALL.FreeBSD
+++ b/INSTALL.FreeBSD
@@ -1,30 +1,35 @@
-Install required libaries:
-
-xmlrpc-c
-cd /usr/ports/net/xmlrpc-c; make install clean (activate curl)
-
-Install optional libaries:
-
-libGSL
-cd /usr/ports/math/gsl; make install clean
-
-libpcap
-cd /usr/ports/lib/pcap: make install clean
+Tested with
+-----------
+FreeBSD 9.1-RELEASE
 
 
-extract flowgrind archive:
-tar xjvf flowgrind-*.tar.bz2
-cd flowgrind-*
+RELEASE VERSION installation
+----------------------------
+Straight forward installation using port tree:
+  cd /usr/ports/benchmarks/flowgrind; make install clean
 
-configure sources:
 
-CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib ./configure
+TARBALL VERSION Installation
+----------------------------
+Install required xmlrpc-c library:
+  cd /usr/ports/net/xmlrpc-c; make install clean (activate curl)
 
-build sources:
-make
+Install optional libGSL and libpcap library if you want to
+use all flowgrind features:
+  cd /usr/ports/math/gsl; make install clean
+  cd /usr/ports/net/libpcap; make install clean
 
-install it
-make install
+Extract archive:
+  tar xjvf flowgrind-*.tar.bz2
+  cd flowgrind-*
 
-Hint:
-currently sysctl net.inet6.ip6.v6only=0 (disables ipv6) might be required.
+Configure sources:
+  CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib ./configure
+
+Build and installl flowgrind:
+  make && make install
+
+
+Hint
+----
+Currently sysctl net.inet6.ip6.v6only=0 (disables ipv6) might be required.

--- a/INSTALL.Ubuntu
+++ b/INSTALL.Ubuntu
@@ -1,8 +1,16 @@
+Tested with
+-----------
+Ubuntu 13.04  (Raring Ringtail)
+
+
+PPA VERSION Installation
+------------------------
+
 Add UMIC-Mesh.net Repository:
-sudo add-apt-repository ppa:umic-mesh/flowgrind
+  sudo add-apt-repository ppa:umic-mesh/flowgrind
 
 Update Package List:
-sudo apt-get update
+  sudo apt-get update
 
-Install Flowgrind:
-sudo aptitude install flowgrind
+Install flowgrind:
+  sudo aptitude install flowgrind

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,3 @@
-
-
 flowgrind (0.6.0) unstable; urgency=low
 
   Release: 0.6.0 (2013-4-24):


### PR DESCRIPTION
- Generic: align file layout with other installation instructions
- Debian: ensure that debhelper, cdbs, autotools-dev is installed
- Ubuntu, Debian: aptitude is not part of baseline installation. use apt-get instead
- FreeBSD: fix typo, fix path for libpcap
