### PR TITLE
Flowgrind bulktrans

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -100,7 +100,8 @@ enum _stochastic_distributions
 	UNIFORM,
 	EXPONENTIAL,
 	PARETO,
-	LOGNORMAL
+	LOGNORMAL,
+	ONCE
 };
 
 struct _trafgen_options

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -148,7 +148,12 @@ static inline int flow_sending(struct timeval *now, struct _flow *flow,
 {
 	return !flow_in_delay(now, flow, direction) &&
 		(flow->settings.duration[direction] < 0 ||
-		 time_diff_now(&flow->stop_timestamp[direction]) < 0.0);
+		 time_diff_now(&flow->stop_timestamp[direction]) < 0.0 ||
+		(flow->settings.request_trafgen_options.distribution == ONCE &&
+		direction == WRITE && flow->settings.response_trafgen_options.param_one > 0 &&
+		flow->current_write_block_size > flow->current_block_bytes_written) ||
+		(flow->settings.request_trafgen_options.distribution == ONCE &&
+		direction == READ && flow->current_read_block_size > flow->current_block_bytes_read));
 }
 
 static inline int flow_block_scheduled(struct timeval *now, struct _flow *flow)
@@ -289,11 +294,9 @@ static int prepare_fds() {
 
 		if (started &&
 		    (flow->finished[READ] ||
-		     !flow->settings.duration[READ] ||
 		     (!flow_in_delay(&now, flow, READ) &&
 		      !flow_sending(&now, flow, READ))) &&
 		    (flow->finished[WRITE] ||
-		     !flow->settings.duration[WRITE] ||
 		     (!flow_in_delay(&now, flow, WRITE) &&
 		      !flow_sending(&now, flow, WRITE)))) {
 
@@ -976,11 +979,13 @@ static int write_data(struct _flow *flow)
 			       flow->current_write_block_size);
 #endif
 			/* we just finished writing a block */
-			flow->current_block_bytes_written = 0;
 			tsc_gettimeofday(&flow->last_block_written);
 			for (int i = 0; i < 2; i++)
 				flow->statistics[i].request_blocks_written++;
+			if (flow->settings.response_trafgen_options.distribution == ONCE)
+				continue;
 
+			flow->current_block_bytes_written = 0;
 			interpacket_gap = next_interpacket_gap(flow);
 
 			/* if we calculated a non-zero packet add relative time
@@ -1149,6 +1154,8 @@ static int read_data(struct _flow *flow)
 				for (int i = 0; i < 2; i++)
 					flow->statistics[i].response_blocks_read++;
 				process_rtt(flow);
+				if (flow->settings.response_trafgen_options.distribution == ONCE)
+					return rc;
 
 			} else {
 				/* this is a request block, calculate IAT */
@@ -1158,9 +1165,12 @@ static int read_data(struct _flow *flow)
 
 				/* send response if requested */
 				if (requested_response_block_size >=
-				    (signed)MIN_BLOCK_SIZE && !flow->finished[READ])
+				    (signed)MIN_BLOCK_SIZE && !flow->finished[READ]) {
 					send_response(flow,
 						      requested_response_block_size);
+					if (flow->settings.request_trafgen_options.distribution == ONCE)
+						return (-1);
+				}
 			}
 		}
 		if (!flow->settings.pushy)

--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -72,6 +72,7 @@ struct _opt opt;
 static struct _flow flow[MAX_FLOWS];
 
 int active_flows = 0;
+int is_bulkopt = 0, is_trafgenopt = 0, is_timeopt = 0;
 
 enum _column_types
 {
@@ -673,7 +674,8 @@ static void usage(void)
 		"               truncates values if used with stochastic traffic generation\n"
 		"  -T x=#.#     Set flow duration, in seconds (default: s=10,d=0)\n"
 		"  -W x=#       Set requested receiver buffer (advertised window) in bytes\n"
-		"  -Y x=#.#     Set initial delay before the host starts to send data\n\n",
+		"  -Y x=#.#     Set initial delay before the host starts to send data\n"
+		"  -Z x=#.#     Set bulk data transfer\n\n",
 		opt.log_filename_prefix,
 		progname,
 		MIN_BLOCK_SIZE
@@ -794,6 +796,17 @@ static void usage_trafgenopt(void)
 		"  they overwrite each other. -A, -R and -V exist for backward compatibility.\n"
 
 		);
+	exit(1);
+}
+
+static void usage_optcombination(void)
+{
+	fprintf(stderr, "Flowgrind cannot set flow duration, traffic generation and "
+			"bulk data transfer options at the same time.\n"
+			"- If you use bulk data transfer option (-Z), don't set flow duration (-T) "
+			"and traffic generation (-G, -A or -S) options\n"
+			"- If you use either flow duration or traffic generation option, "
+			"or both of them, don't set bulk data transfer option\n\n");
 	exit(1);
 }
 
@@ -1737,8 +1750,11 @@ static void parse_flow_option(int ch, char* optarg, int current_flow_ids[], int 
 
 		switch (ch) {
 			case 'A':
+				if (is_bulkopt)
+					usage_optcombination();
 				ASSIGN_COMMON_FLOW_SETTING(response_trafgen_options.distribution, CONSTANT);
 				ASSIGN_COMMON_FLOW_SETTING(response_trafgen_options.param_one, MIN_BLOCK_SIZE);
+				is_trafgenopt++;
 				break;
 			case 'B':
 				rc = sscanf(arg, "%u", &optunsigned);
@@ -1920,6 +1936,8 @@ static void parse_flow_option(int ch, char* optarg, int current_flow_ids[], int 
 				break;
 
 			case 'S':
+				if (is_bulkopt)
+					usage_optcombination();
 				rc = sscanf(arg, "%u", &optunsigned);
 				ASSIGN_COMMON_FLOW_SETTING(request_trafgen_options.distribution, CONSTANT);
 				ASSIGN_COMMON_FLOW_SETTING(request_trafgen_options.param_one, optunsigned);
@@ -1929,15 +1947,24 @@ static void parse_flow_option(int ch, char* optarg, int current_flow_ids[], int 
 							flow[id].settings[i].maximum_block_size = (signed)optunsigned;
 					}
 				}
+				is_trafgenopt++;
 				break;
 
 			case 'T':
+				if (is_bulkopt) {
+					fprintf(stderr, "Cannot set flow duration, bulk "
+							"data transfer and traffic generation "
+							"options at the same time.\n"
+							"Disable either of them\n");
+					exit(1);
+				}
 				rc = sscanf(arg, "%lf", &optdouble);
 				if (rc != 1) {
 					fprintf(stderr, "malformed flow duration\n");
 					usage();
 				}
 				ASSIGN_COMMON_FLOW_SETTING(duration[WRITE], optdouble)
+				is_timeopt++;
 				break;
 
 			case 'W':
@@ -1959,6 +1986,38 @@ static void parse_flow_option(int ch, char* optarg, int current_flow_ids[], int 
 				}
 				ASSIGN_COMMON_FLOW_SETTING(delay[WRITE], optdouble)
 				break;
+			case 'Z':
+			{
+				if (is_trafgenopt || is_timeopt)
+					usage_optcombination();
+				rc = sscanf(arg, "%lf", &optdouble);
+				if (rc != 1 || optdouble < 0) {
+					fprintf(stderr, "Data to be sent must be a non-negativ "
+							"number (in bytes)\n");
+					usage();
+				}
+				if (current_flow_ids[0] == -1) {
+					for (int id = 0; id < MAX_FLOWS; id++) {
+						for (int i = 0; i < 2; i++) {
+							if ((signed)optdouble > flow[id].settings[i].maximum_block_size)
+								flow[id].settings[i].maximum_block_size = (signed)optdouble;
+							flow[id].settings[i].request_trafgen_options.distribution = ONCE;
+						}
+					}
+				} else {
+					for (int i = 0; i < 2; i++) {
+						if ((signed)optdouble > flow[current_flow_ids[id]].settings[i].maximum_block_size)
+							flow[current_flow_ids[id]].settings[i].maximum_block_size = (signed)optdouble;
+						flow[current_flow_ids[id]].settings[i].request_trafgen_options.distribution = ONCE;
+					}
+				}
+				ASSIGN_COMMON_FLOW_SETTING(duration[WRITE], 0);
+				ASSIGN_COMMON_FLOW_SETTING(request_trafgen_options.param_one, optdouble);
+				ASSIGN_COMMON_FLOW_SETTING(response_trafgen_options.distribution, ONCE);
+				ASSIGN_COMMON_FLOW_SETTING(response_trafgen_options.param_one, MIN_BLOCK_SIZE);
+				is_bulkopt++;
+				break;
+			}
 		}
 	}
 
@@ -2037,7 +2096,7 @@ static void parse_cmdline(int argc, char **argv) {
 		}
 	}
 
-	while ((ch = getopt(argc, argv, "c:de:h:i:l:mn:opqr:vwA:B:CD:EF:G:H:J:LNM:O:P:QR:S:T:U:W:Y:")) != -1)
+	while ((ch = getopt(argc, argv, "c:de:h:i:l:mn:opqr:vwA:B:CD:EF:G:H:J:LNM:O:P:QR:S:T:U:W:Y:Z:")) != -1)
 
 		switch (ch) {
 
@@ -2136,7 +2195,10 @@ static void parse_cmdline(int argc, char **argv) {
 			current_flow_ids[id] = -1;
 			break;
 		case 'G':
+			if (is_bulkopt)
+				usage_optcombination();
 			parse_trafgen_option(optarg, current_flow_ids, id-1);
+			is_trafgenopt++;
 			break;
 		case 'J':
 			rc = sscanf(optarg, "%u", &optint);
@@ -2178,6 +2240,7 @@ static void parse_cmdline(int argc, char **argv) {
 		case 'T':
 		case 'W':
 		case 'Y':
+		case 'Z':
 			parse_flow_option(ch, optarg, current_flow_ids, id-1);
 			break;
 
@@ -2236,19 +2299,23 @@ static void parse_cmdline(int argc, char **argv) {
 			error = 1;
 		}
 		if (flow[id].settings[SOURCE].delay[WRITE] > 0 &&
-				flow[id].settings[SOURCE].duration[WRITE] == 0) {
+				(flow[id].settings[SOURCE].duration[WRITE] == 0 &&
+				flow[id].settings[SOURCE].request_trafgen_options.distribution != ONCE)) {
 			fprintf(stderr, "Client flow %d has a delay but "
 					"no runtime.\n", id);
 			error = 1;
 		}
 		if (flow[id].settings[DESTINATION].delay[WRITE] > 0 &&
-				flow[id].settings[DESTINATION].duration[WRITE] == 0) {
+				(flow[id].settings[DESTINATION].duration[WRITE] == 0 &&
+				flow[id].settings[DESTINATION].request_trafgen_options.distribution != ONCE)) {
 			fprintf(stderr, "Server flow %d has a delay but "
 					"no runtime.\n", id);
 			error = 1;
 		}
 		if (!flow[id].settings[DESTINATION].duration[WRITE] &&
-				!flow[id].settings[SOURCE].duration[WRITE]) {
+				!flow[id].settings[SOURCE].duration[WRITE] &&
+				(flow[id].settings[SOURCE].request_trafgen_options.distribution != ONCE &&
+				flow[id].settings[DESTINATION].request_trafgen_options.distribution != ONCE)) {
 			fprintf(stderr, "Server and client flow have both "
 					"zero runtime for flow %d.\n", id);
 			error = 1;
@@ -2630,6 +2697,11 @@ void prepare_flow(int id, xmlrpc_client *rpc_client)
 	}
 	DEBUG_MSG(LOG_WARNING, "prepare flow %d source", id);
 
+#ifdef DEBUG
+	struct timeval now;
+	tsc_gettimeofday(&now);
+	DEBUG_MSG(LOG_DEBUG, "%ld.%ld (add_flow_source() in flowgrind.c)\n", now.tv_sec, now.tv_usec);
+#endif
 	xmlrpc_client_call2f(&rpc_env, rpc_client,
 		flow[id].endpoint_options[SOURCE].daemon->server_url,
 		"add_flow_source", &resultP,

--- a/src/trafgen.c
+++ b/src/trafgen.c
@@ -79,6 +79,9 @@ inline static double calculate(struct _flow *flow, enum _stochastic_distribution
 			DEBUG_MSG(LOG_DEBUG, "calculated lognormal distribution value %f for parameters %f,%f", val, param_one, param_two);
 		break;
 
+		case ONCE:
+			val = param_one;
+		break;
 		case CONSTANT:
 		/* constant is default */
 		default:


### PR DESCRIPTION
I extend flowgrind for bulk data transfer. Now you can transfer specific data size once using Z option.
Here is an example to transfer 10KB data in local network:
$ flowgrind -Z s=10000
The data transfer time appears as RTT in the final result.

This option cannot use traffic generation (-A, -G, -Z) and flow duration (-T) options. The usage message has been included in this branch.

I have an issue to be mentioned. Using Z option takes more time to generate flows than using G option when we generate more than 4 flows between two hosts. This issue occurs when we generate more than 4 flows, which are generated by different combination of hosts. The only way to avoid this problem is to use 10Gbps link for management link.
Why flow generation using Z option takes time is not clear yet. The only thing I know is to take longer time when flowgrind prepares flows (add_flow_source() in flowgrind.c). Using G option takes less than 4 millisecond in the loop of  this function when flowgrind generates 10 TCP connections. On the other hand,  using Z option takes more than 1 second. If you got the main cause, please apply your patch to this branch.

Also, I find a bug for flow parameter specification. It's fixed in this branch.
