### PR TITLE
Fixed build break in case libpcap-dev is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,7 @@ fi
 AC_ARG_ENABLE(pcap,[AS_HELP_STRING(--enable-pcap, enable lipcap for packet capturing [[default: yes]] )])
 AS_IF([ test "x$enable_pcap" != "xno"], [
         AC_CHECK_HEADER(pcap.h,
-                AC_CHECK_LIB([pcap], pcap_open_live, [AC_DEFINE(HAVE_LIBPCAP, 1, [Define to 1 if you have the pcap library (-lpcap).])],
+                AC_CHECK_LIB([pcap], pcap_open_live, [LINKABLE_LIBPCAP=1 AC_DEFINE(HAVE_LIBPCAP, 1, [Define to 1 if you have the pcap library (-lpcap).])],
                 AC_MSG_NOTICE([*** Could not find libpcap: will compile without optional traffic dump feature. ***]),[-lpcap]),
                 AC_MSG_NOTICE([*** Header file pcap.h not found: will compile without optional traffic dump. ***]))
 
@@ -155,6 +155,7 @@ AS_IF([ test "x$enable_pcap" != "xno"], [
         AC_SUBST(PCAP_LDADD)
     fi
 ])
+AM_CONDITIONAL([USE_LIBPCAP], [test "x$enable_pcap" != "xno" -a "$LINKABLE_LIBPCAP" -eq 1])
 
 AC_ARG_ENABLE(gsl,[AS_HELP_STRING(--enable-gsl, enable GNU Scientific Library [[default: yes]] )])
 AS_IF([ test "x$enable_gsl" != "xno"], [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,12 +11,19 @@ flowgrind_LDADD = $(LIBS) $(CURL_LDADD) $(XMLRPC_C_CLIENT_LDADD) $(GSL_LDADD)
 flowgrind_CFLAGS = $(AM_CFLAGS) $(CURL_CFLAGS) $(XMLRPC_C_CLIENT_CFLAGS) $(GSL_CFLAGS)
 
 flowgrindd_SOURCES = common.h daemon.h daemon.c debug.c destination.h destination.c \
-					 fg_error.h fg_error.c fg_math.h fg_math.c fg_pcap.h fg_pcap.c \
+					 fg_error.h fg_error.c fg_math.h fg_math.c \
 					 fg_progname.h fg_progname.c fg_socket.c fg_socket.h fg_string.h \
 					 fg_string.c fg_time.c  flowgrindd.c log.h log.c source.h  source.c \
 					 trafgen.h trafgen.c
-flowgrindd_LDADD = $(LIBS) $(XMLRPC_C_SERVER_LDADD) $(PCAP_LDADD) $(GSL_LDADD)
-flowgrindd_CFLAGS = $(AM_CFLAGS) $(PCAP_CFLAGS) $(XMLRPC_C_SERVER_CFLAGS) $(GSL_CFLAGS)
+
+flowgrindd_LDADD = $(LIBS) $(XMLRPC_C_SERVER_LDADD) $(GSL_LDADD)
+flowgrindd_CFLAGS = $(AM_CFLAGS) $(XMLRPC_C_SERVER_CFLAGS) $(GSL_CFLAGS)
+
+if USE_LIBPCAP
+    flowgrindd_SOURCES += fg_pcap.h fg_pcap.c
+    flowgrindd_LDADD += $(PCAP_LDADD)
+    flowgrindd_CFLAGS += $(PCAP_CFLAGS)
+endif
 
 flowgrind_stop_SOURCES = fg_error.h fg_error.c fg_progname.h fg_progname.c flowgrind_stop.c
 flowgrind_stop_LDADD = $(LIBS) $(CURL_LDADD) $(XMLRPC_C_CLIENT_LDADD)

--- a/src/destination.c
+++ b/src/destination.c
@@ -52,12 +52,15 @@
 
 #include "common.h"
 #include "debug.h"
-#include "fg_pcap.h"
 #include "fg_socket.h"
 #include "fg_time.h"
 #include "fg_math.h"
 #include "log.h"
 #include "daemon.h"
+
+#ifdef HAVE_LIBPCAP
+#include "fg_pcap.h"
+#endif /* HAVE_LIBPCAP */
 
 void remove_flow(unsigned int i);
 

--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -235,7 +235,7 @@ static void usage(short status)
 #endif /* DEBUG */
 #ifdef HAVE_LIBPCAP
 		"  -e, --dump-prefix=PRE\n"
-		"                 prepend prefix PRE to dump filename (default: \"%2$s\")\n"
+		"                 prepend prefix PRE to dump filename (default: \"%3$s\")\n"
 #endif /* HAVE_LIBPCAP */
 		"  -i, --report-interval=#.#\n"
 		"                 reporting interval, in seconds (default: 0.05s)\n"
@@ -259,7 +259,7 @@ static void usage(short status)
 		"  instance -W s=8192,d=4096 sets the advertised window to 8192 at the source\n"
 		"  and 4096 at the destination.\n\n"
 		"  -A x           use minimal response size needed for RTT calculation\n"
-		"                 (same as -G s=p,C,%3$d)\n"
+		"                 (same as -G s=p,C,%2$d)\n"
 		"  -B x=#         set requested sending buffer, in bytes\n"
 		"  -C x           stop flow if it is experiencing local congestion\n"
 		"  -D x=DSCP      DSCP value for TOS byte\n"
@@ -306,7 +306,12 @@ static void usage(short status)
 		"  -W x=#         set requested receiver buffer (advertised window), in bytes\n"
 		"  -Y x=#.#       set initial delay before the host starts to send, in seconds\n"
 /*		"  -Z x=#.#       set amount of data to be send, in bytes (instead of -t)\n"*/,
-		progname, copt.dump_prefix, MIN_BLOCK_SIZE);
+		progname,
+		MIN_BLOCK_SIZE
+#ifdef HAVE_LIBPCAP
+		, copt.dump_prefix
+#endif /* HAVE_LIBPCAP */
+		);
 	exit(EXIT_SUCCESS);
 }
 
@@ -2602,7 +2607,9 @@ static void parse_cmdline(int argc, char *argv[]) {
 #ifdef DEBUG
 		{"debug", no_argument, 0, 'd'},
 #endif /* DEBUG */
+#ifdef HAVE_LIBPCAP
 		{"dump-prefix", required_argument, 0, 'e'},
+#endif /* HAVE_LIBPCAP */
 		{"report-interval", required_argument, 0, 'i'},
 		{"log-file", optional_argument, 0, LOG_FILE_OPTION},
 		{"flows", required_argument, 0, 'n'},
@@ -2612,13 +2619,15 @@ static void parse_cmdline(int argc, char *argv[]) {
 	};
 
 	/* short options */
+	static const char *short_opt = "hvc:"
 #ifdef DEBUG
-	static const char *short_opt = "hvc:de:i:mn:opqs:w"
-		"A:B:CD:EF:G:H:IJ:LNM:O:P:QR:S:T:U:W:Y:";
-#else
-	static const char *short_opt = "hvc:e:i:mn:opqs:w"
-		"A:B:CD:EF:G:H:IJ:LNM:O:P:QR:S:T:U:W:Y:";
+		"d"
 #endif /* DEBUG */
+#ifdef HAVE_LIBPCAP
+		"e:"
+#endif /* HAVE_LIBPCAP */
+		"i:mn:opqs:w"
+		"A:B:CD:EF:G:H:IJ:LNM:O:P:QR:S:T:U:W:Y:";
 
 	/* variables from getopt() */
 	extern char *optarg;	/* option argument */
@@ -2659,9 +2668,11 @@ static void parse_cmdline(int argc, char *argv[]) {
 		case 'd':
 			increase_debuglevel();
 			break;
+#ifdef HAVE_LIBPCAP
 		case 'e':
 			copt.dump_prefix = optarg;
 			break;
+#endif /* HAVE_LIBPCAP */
 		case 'i':
 			rc = sscanf(optarg, "%lf", &copt.reporting_interval);
 			if (rc != 1 || copt.reporting_interval <= 0) {

--- a/src/source.c
+++ b/src/source.c
@@ -57,10 +57,13 @@
 #include "debug.h"
 #include "fg_error.h"
 #include "fg_math.h"
-#include "fg_pcap.h"
 #include "fg_socket.h"
 #include "fg_time.h"
 #include "log.h"
+
+#ifdef HAVE_LIBPCAP
+#include "fg_pcap.h"
+#endif /* HAVE_LIBPCAP */
 
 void remove_flow(unsigned int i);
 


### PR DESCRIPTION
Resubmission of pull request #71 as requested.

In case libpcap-dev was not available or the --enable-pcap=no option was used, compilation failed. This should now be fixed.
