### PR TITLE
Fixed wrong use of errno in error conditions after a call to a pthread function

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -185,7 +185,7 @@ void uninit_flow(struct _flow *flow)
 		rc = pthread_cancel(flow->pcap_thread);
 		if (rc)
 			logging_log(LOG_WARNING, "failed to cancel dump "
-				    "thread: %s", strerror(errno));
+				    "thread: %s", strerror(rc));
 		fg_pcap_cleanup(flow);
 	}
 #endif

--- a/src/fg_pcap.c
+++ b/src/fg_pcap.c
@@ -325,7 +325,7 @@ void fg_pcap_go(struct _flow *flow)
 #endif /* __DARWIN__ */
 	if (rc)
 		logging_log(LOG_WARNING, "Could not start pcap thread: %s",
-			    strerror(errno) );
+			    strerror(rc) );
 	return;
 }
 

--- a/src/flowgrindd.c
+++ b/src/flowgrindd.c
@@ -853,7 +853,7 @@ void create_daemon_thread()
 
 	int rc = pthread_create(&daemon_thread, NULL, daemon_main, 0);
 	if (rc)
-		crit("could not start thread");
+		critc(rc, "could not start thread");
 }
 
 /* creates listen socket for the xmlrpc server */


### PR DESCRIPTION
Fix for issue #85

Fixed wrong use of errno in error conditions after a call to a pthread function
