### PR TITLE
Fixed bugs in vasprintf_append()

### DIFF
--- a/src/fg_string.c
+++ b/src/fg_string.c
@@ -115,12 +115,14 @@ int vasprintf_append(char **strp, const char *fmt, va_list ap)
 	size_t alen = fmtlen(fmt, ap);
 
 	/* The format resulted in no characters being formatted */
-	if (unlikely(alen = 0))
+	if (unlikely(alen == 0))
 		return -1;
 
-	*strp = realloc(*strp, slen + alen + 1);
-	if (unlikely(!(*strp)))
+	char *new_strp = realloc(*strp, slen + alen + 1);
+	if (unlikely(!(*new_strp)))
 		return -1;
+
+	*strp = new_strp;
 
 	va_list ap2;
 	va_copy(ap2, ap);


### PR DESCRIPTION
- fixed bug in vasprintf_append() causing the input string to stay unchanged
  *\* alen was accidentally set to 0 leading to vsnprintf() always being called with 1 as second argument, so only the terminating 0 was "appended"
- fixed possible memleak in vasprintf_append() in case realloc fails
  *\* if realloc fails we (may) loose track of the memory to which *strp points resulting in a memory leak. *strp should only be overwritten if realloc succeeds.
