### PR TITLE
Fix issue #148

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -653,10 +653,12 @@ int get_tcp_info(struct flow *flow, struct fg_tcp_info *info)
 	CPY_INFO_MEMBER(tcpi_backoff);
 	CPY_INFO_MEMBER(tcpi_unacked);
 	CPY_INFO_MEMBER(tcpi_sacked);
+	CPY_INFO_MEMBER(tcpi_lost);
 	CPY_INFO_MEMBER(tcpi_retrans);
 	CPY_INFO_MEMBER(tcpi_retransmits);
 	CPY_INFO_MEMBER(tcpi_fackets);
 	CPY_INFO_MEMBER(tcpi_reordering);
+	CPY_INFO_MEMBER(tcpi_ca_state);
 #endif /* __LINUX__ */
 #else /* HAVE_TCP_INFO */
 	UNUSED_ARGUMENT(flow);


### PR DESCRIPTION
With commit 65b8fb4 the two members tcpi_lost and tcpi_ca_state
wasn't longer filled w/ the tcp info struct values
