### PR TITLE
make RPC api independent of libpcap availability

### DIFF
--- a/src/daemon.h
+++ b/src/daemon.h
@@ -250,10 +250,9 @@ extern unsigned int pending_reports;
  * large a reply can get */
 struct report* get_reports(int *has_more);
 
-#ifdef HAVE_LIBPCAP
+/* FIXME: shouldn't be global? */
 char *dump_prefix;
 char *dump_dir;
-#endif /* HAVE_LIBPCAP */
 
 void *daemon_main(void* ptr);
 void add_report(struct report* report);

--- a/src/destination.c
+++ b/src/destination.c
@@ -165,7 +165,7 @@ void add_flow_destination(struct request_add_flow_destination *request)
 		logging_log(LOG_ALERT, "could not allocate memory for flow");
 		return;
 	}
-	
+
 	init_flow(flow, 0);
 
 	flow->settings = request->settings;

--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -244,10 +244,8 @@ static void usage(short status)
 		"  -d, --debug    increase debugging verbosity. Add option multiple times to\n"
 		"                 increase the verbosity\n"
 #endif /* DEBUG */
-#ifdef HAVE_LIBPCAP
 		"  -e, --dump-prefix=PRE\n"
-		"                 prepend prefix PRE to dump filename (default: \"%3$s\")\n"
-#endif /* HAVE_LIBPCAP */
+		"                 prepend prefix PRE to pcap dump filename (default: \"%3$s\")\n"
 		"  -i, --report-interval=#.#\n"
 		"                 reporting interval, in seconds (default: 0.05s)\n"
 		"      --log-file[=FILE]\n"
@@ -296,9 +294,7 @@ static void usage(short status)
 		"  -L             call connect() on test socket immediately before starting to\n"
 		"                 send data (late connect). If not specified the test connection\n"
 		"                 is established in the preparation phase before the test starts\n"
-#ifdef HAVE_LIBPCAP
 		"  -M x           dump traffic using libpcap. flowgrindd must be run as root\n"
-#endif /* HAVE_LIBPCAP */
 		"  -N             shutdown() each socket direction after test flow\n"
 		"  -O x=OPT       set socket option OPT on test socket. For additional information\n"
 		"                 see 'flowgrind --help=socket'\n"
@@ -318,9 +314,7 @@ static void usage(short status)
 /*		"  -Z x=#.#       set amount of data to be send, in bytes (instead of -t)\n"*/,
 		progname,
 		MIN_BLOCK_SIZE
-#ifdef HAVE_LIBPCAP
 		, copt.dump_prefix
-#endif /* HAVE_LIBPCAP */
 		);
 	exit(EXIT_SUCCESS);
 }
@@ -484,9 +478,7 @@ static void init_controller_options(void)
 	copt.reporting_interval = 0.05;
 	copt.log_to_stdout = true;
 	copt.log_to_file = false;
-#ifdef HAVE_LIBPCAP
 	copt.dump_prefix = "flowgrind-";
-#endif /* HAVE_LIBPCAP */
 	copt.clobber = false;
 	copt.mbyte = false;
 	copt.symbolic = true;
@@ -827,9 +819,7 @@ static void prepare_flow(int id, xmlrpc_client *rpc_client)
 		"{s:b,s:b,s:i,s:i}"
 		"{s:s}"
 		"{s:i,s:i,s:i,s:i,s:i}"
-#ifdef HAVE_LIBPCAP
 		"{s:s}"
-#endif /* HAVE_LIBPCAP */
 		"{s:i,s:A}"
 		")",
 
@@ -880,9 +870,7 @@ static void prepare_flow(int id, xmlrpc_client *rpc_client)
 		"mtcp", cflow[id].settings[DESTINATION].mtcp,
 		"dscp", (int)cflow[id].settings[DESTINATION].dscp,
 		"ipmtudiscover", cflow[id].settings[DESTINATION].ipmtudiscover,
-#ifdef HAVE_LIBPCAP
 		"dump_prefix", copt.dump_prefix,
-#endif /* HAVE_LIBPCAP */
 		"num_extra_socket_options", cflow[id].settings[DESTINATION].num_extra_socket_options,
 		"extra_socket_options", extra_options);
 
@@ -933,9 +921,7 @@ static void prepare_flow(int id, xmlrpc_client *rpc_client)
 		"{s:b,s:b,s:i,s:i}"
 		"{s:s}"
 		"{s:i,s:i,s:i,s:i,s:i}"
-#ifdef HAVE_LIBPCAP
 		"{s:s}"
-#endif /* HAVE_LIBPCAP */
 		"{s:i,s:A}"
 		"{s:s,s:i,s:i}"
 		")",
@@ -988,9 +974,7 @@ static void prepare_flow(int id, xmlrpc_client *rpc_client)
 		"mtcp", cflow[id].settings[SOURCE].mtcp,
 		"dscp", (int)cflow[id].settings[SOURCE].dscp,
 		"ipmtudiscover", cflow[id].settings[SOURCE].ipmtudiscover,
-#ifdef HAVE_LIBPCAP
 		"dump_prefix", copt.dump_prefix,
-#endif /* HAVE_LIBPCAP */
 		"num_extra_socket_options", cflow[id].settings[SOURCE].num_extra_socket_options,
 		"extra_socket_options", extra_options,
 
@@ -2573,11 +2557,9 @@ static void parse_general_option(int code, const char* arg, const char* opt_stri
 		increase_debuglevel();
 		break;
 #endif /* DEBUG */
-#ifdef HAVE_LIBPCAP
 	case 'e':
 		copt.dump_prefix = strdup(arg);
 		break;
-#endif /* HAVE_LIBPCAP */
 	case 'i':
 		if (sscanf(arg, "%lf", &copt.reporting_interval) != 1 ||
 					copt.reporting_interval <= 0)
@@ -2727,9 +2709,7 @@ static void parse_cmdline(int argc, char *argv[])
 #ifdef DEBUG
 		{'d', "debug", ap_no, OPT_CONTROLLER, 0},
 #endif /* DEBUG */
-#ifdef HAVE_LIBPCAP
 		{'e', "dump-prefix", ap_yes, OPT_CONTROLLER, 0},
-#endif /* HAVE_LIBPCAP */
 		{'h', "help", ap_maybe, OPT_CONTROLLER, 0},
 		{'i', "report-interval", ap_yes, OPT_CONTROLLER, 0},
 		{LOG_FILE_OPTION, "log-file", ap_maybe, OPT_CONTROLLER, 0},

--- a/src/flowgrind.h
+++ b/src/flowgrind.h
@@ -167,10 +167,8 @@ struct controller_options {
 	bool log_to_stdout;
 	/** Write output to logfile (option -w) */
 	bool log_to_file;
-#ifdef HAVE_LIBPCAP
 	/** Prefix for dumpfile (option -e) */
 	const char *dump_prefix;
-#endif /* HAVE_LIBPCAP */
 	/** Overwrite existing log files (option -o) */
 	bool clobber;
 	/** Report in MByte/s instead of MBit/s (option -m) */

--- a/src/flowgrindd.c
+++ b/src/flowgrindd.c
@@ -240,9 +240,7 @@ static xmlrpc_value * add_flow_source(xmlrpc_env * const env,
 		"{s:b,s:b,s:i,s:i,*}"
 		"{s:s,*}"
 		"{s:i,s:i,s:i,s:i,s:i,*}"
-#ifdef HAVE_LIBPCAP
-		"{s:s,*}"
-#endif /* HAVE_LIBPCAP */
+		"{s:s,*}" /* for LIBPCAP dumps */
 		"{s:i,s:A,*}"
 		"{s:s,s:i,s:i,*}"
 		")",
@@ -294,9 +292,7 @@ static xmlrpc_value * add_flow_source(xmlrpc_env * const env,
 		"mtcp", &settings.mtcp,
 		"dscp", &settings.dscp,
 		"ipmtudiscover", &settings.ipmtudiscover,
-#ifdef HAVE_LIBPCAP
 		"dump_prefix", &dump_prefix,
-#endif /* HAVE_LIBPCAP */
 		"num_extra_socket_options", &settings.num_extra_socket_options,
 		"extra_socket_options", &extra_options,
 
@@ -307,6 +303,11 @@ static xmlrpc_value * add_flow_source(xmlrpc_env * const env,
 
 	if (env->fault_occurred)
 		goto cleanup;
+
+#ifndef HAVE_LIBPCAP
+	if (settings.traffic_dump)
+		XMLRPC_FAIL(env, XMLRPC_TYPE_ERROR, "Daemon was asked to dump traffic, but wasn't compiled with libpcap support");
+#endif
 
 	/* Check for sanity */
 	if (strlen(bind_address) >= sizeof(settings.bind_address) - 1 ||
@@ -432,9 +433,7 @@ static xmlrpc_value * add_flow_destination(xmlrpc_env * const env,
 		"{s:b,s:b,s:i,s:i,*}"
 		"{s:s,*}"
 		"{s:i,s:i,s:i,s:i,s:i,*}"
-#ifdef HAVE_LIBPCAP
-		"{s:s,*}"
-#endif /* HAVE_LIBPCAP */
+		"{s:s,*}" /* For libpcap dumps */
 		"{s:i,s:A,*}"
 		")",
 
@@ -485,14 +484,19 @@ static xmlrpc_value * add_flow_destination(xmlrpc_env * const env,
 		"mtcp", &settings.mtcp,
 		"dscp", &settings.dscp,
 		"ipmtudiscover", &settings.ipmtudiscover,
-#ifdef HAVE_LIBPCAP
 		"dump_prefix", &dump_prefix,
-#endif /* HAVE_LIBPCAP */
 		"num_extra_socket_options", &settings.num_extra_socket_options,
 		"extra_socket_options", &extra_options);
 
 	if (env->fault_occurred)
 		goto cleanup;
+
+#ifndef HAVE_LIBPCAP
+	if (settings.traffic_dump) {
+		XMLRPC_FAIL(env, XMLRPC_TYPE_ERROR, "Daemon was asked to dump traffic, but wasn't compiled with libpcap support");
+		goto cleanup;
+	}
+#endif
 
 	/* Check for sanity */
 	if (strlen(bind_address) >= sizeof(settings.bind_address) - 1 ||


### PR DESCRIPTION
Before this patch, controller and daemon had to be compiled
with the same featureset reagarding libpcap, that is either
both had to compiled with libcpap or none.

This patch fixes that. The RPCs itself will now always contain
the corresponding options, and the daemon will always be able
to receive them.

However, if the controller asks for dumps, but the daemon
is not compiled with libpcap, it will complain.

As a side effect, we get rid of a lot of #ifdefs

P.S: I'm afraid that patch might be have some (minor) conflicts with Marcel Nehrings branch.
