### PR TITLE
Fix waring: using abs() for floating point type

### DIFF
--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -1333,7 +1333,7 @@ static int det_column_size(double value)
 
 	if (value < 0)
 		i++;
-	while ((abs(value) / (dez - 1.0)) > 1.0) {
+	while ((fabs(value) / (dez - 1.0)) > 1.0) {
 		i++;
 		dez *= 10;
 	}


### PR DESCRIPTION
src/flowgrind.c:1336:10: warning: using integer absolute value function 'abs'
when argument is of floating point type [-Wabsolute-value]
        while ((abs(value) / (dez - 1.0)) > 1.0) {
                ^
src/flowgrind.c:1336:10: note: use function 'fabs' instead
        while ((abs(value) / (dez - 1.0)) > 1.0) {
                ^~~
                fabs
