### PR TITLE
Fix for Segmentation fault in controller due to daemon wildcard IP address binding

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -277,6 +277,7 @@ struct fg_tcp_info {
 struct report {
 	int id;
 	/* Is this an INTERVAL or FINAL report? */
+	char bind_address[1000];
 	int type;
 	struct timespec begin;
 	struct timespec end;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -508,6 +508,7 @@ static void report_flow(struct flow* flow, int type)
 
 	report->id = flow->id;
 	report->type = type;
+	strcpy(report->bind_address,flow->settings.bind_address);
 
 	if (type == INTERVAL)
 		report->begin = flow->last_report_time;

--- a/src/fg_rpc_server.c
+++ b/src/fg_rpc_server.c
@@ -496,6 +496,7 @@ static xmlrpc_value * method_get_reports(xmlrpc_env * const env,
 			"{s:i,s:i,s:i,s:i,s:i}" /* ...      */
 			"{s:i,s:i,s:i,s:i,s:i}" /* ...      */
 			"{s:i}"
+			"{s:s}"
 			")",
 
 			"id", report->id,
@@ -546,7 +547,9 @@ static xmlrpc_value * method_get_reports(xmlrpc_env * const env,
 			"tcpi_ca_state", (int)report->tcp_info.tcpi_ca_state,
 			"tcpi_snd_mss", (int)report->tcp_info.tcpi_snd_mss,
 
-			"status", report->status
+			"status", report->status,
+
+			"ipaddress",report->bind_address
 		);
 
 		xmlrpc_array_append_item(env, ret, rv);

--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -1023,6 +1023,7 @@ static void fetch_reports(xmlrpc_client *rpc_client)
 {
 
 	xmlrpc_value * resultP = 0;
+	char* bind_address = 0;
 
 	for (unsigned int j = 0; j < num_unique_servers; j++) {
 		int array_size, has_more;
@@ -1093,6 +1094,7 @@ has_more_reports:
 					"{s:i,s:i,s:i,s:i,s:i,*}" /* ...      */
 					"{s:i,s:i,s:i,s:i,s:i,*}" /* ...      */
 					"{s:i,*}"
+					"{s:s,*}"
 					")",
 
 					"id", &report.id,
@@ -1143,8 +1145,9 @@ has_more_reports:
 					"tcpi_ca_state", &tcpi_ca_state,
 					"tcpi_snd_mss", &tcpi_snd_mss,
 
-					"status", &report.status
-				);
+					"status", &report.status,
+
+					"ipaddress", &bind_address);
 				xmlrpc_DECREF(rv);
 #ifdef HAVE_UNSIGNED_LONG_LONG_INT
 				report.bytes_read = ((long long)bytes_read_high << 32) + (uint32_t)bytes_read_low;
@@ -1180,6 +1183,8 @@ has_more_reports:
 				report.end.tv_sec = end_sec;
 				report.end.tv_nsec = end_nsec;
 
+				strcpy(report.bind_address, bind_address);
+
 				report_flow(&unique_servers[j], &report);
 			}
 		}
@@ -1194,7 +1199,6 @@ has_more_reports:
  * by server_url)  to the proper flow */
 static void report_flow(const struct daemon* daemon, struct report* report)
 {
-	const char* server_url = daemon->server_url;
 	int endpoint;
 	int id;
 	struct cflow *f = NULL;
@@ -1205,35 +1209,33 @@ static void report_flow(const struct daemon* daemon, struct report* report)
 		f = &cflow[id];
 
 		for (endpoint = 0; endpoint < 2; endpoint++) {
-			if (f->endpoint_id[endpoint] == report->id &&
-			    !strcmp(server_url, f->endpoint[endpoint].daemon->server_url))
-				goto exit_outer_loop;
-		}
-	}
-exit_outer_loop:
+			if (!strcmp(f->endpoint[endpoint].test_address,report->bind_address)&&
+					(f->endpoint_id[endpoint] == report->id)){
+				if (f->start_timestamp[endpoint].tv_sec == 0)
+					f->start_timestamp[endpoint] = report->begin;
+					
+					if (report->type == FINAL) {
+						DEBUG_MSG(LOG_DEBUG, "received final report for flow %d", id);	
+						free(f->final_report[endpoint]);
+						f->final_report[endpoint] = malloc(sizeof(struct report));
+						*f->final_report[endpoint] = *report;
 
-	if (f->start_timestamp[endpoint].tv_sec == 0)
-		f->start_timestamp[endpoint] = report->begin;
-
-	if (report->type == FINAL) {
-		DEBUG_MSG(LOG_DEBUG, "received final report for flow %d", id);
-		/* Final report, keep it for later */
-		free(f->final_report[endpoint]);
-		f->final_report[endpoint] = malloc(sizeof(struct report));
-		*f->final_report[endpoint] = *report;
-
-		if (!f->finished[endpoint]) {
-			f->finished[endpoint] = 1;
-			if (f->finished[1 - endpoint]) {
-				active_flows--;
-				DEBUG_MSG(LOG_DEBUG, "remaining active flows: "
-					  "%d", active_flows);
-				assert(active_flows >= 0);
+						if (!f->finished[endpoint]) {
+							f->finished[endpoint] = 1;
+							if (f->finished[1 - endpoint]) {
+								active_flows--;
+								DEBUG_MSG(LOG_DEBUG, "remaining active flows: "
+									  "%d", active_flows);
+								assert(active_flows >= 0);
+							}
+						}
+						return;
+					}
+				print_report(id, endpoint, report);
+				return;		
 			}
 		}
-		return;
 	}
-	print_report(id, endpoint, report);
 }
 
 static void close_flows(void)


### PR DESCRIPTION
Test case:
1. Consider node M1 has 3 Ethernet interface M1a, M1b, M1c and Node M2 has 3 Ethernet interface M2a, M2b, M2c.
2. Daemon D1 running in M1 and D2 running in M2.
2. Run the controller C with first flow option, -F 0 -H s=M1a,d=M2a -F 1 -H s=M1b,d=M2b -F 2 s=M1c,d=M2c and second flow option -F 0 -H s=M1a,d=M1b.
3. Both flow option results in the segmentation fault in controller( #164 ).

Problem:
1. Running the daemon without binding to XML-RPC server bind address(flowgrindd -d), binds daemon to the wildcard address (0.0.0.0) for RPC communication between daemon and controller.
2. The report matching in controller report_flow() depends on  comparing report ID and flow ID, and also comparing  daemon RPC URL connection string.
3. When C asks for source report in M1 for source M1a, then daemon D1 generate reports of M1a, M1b, and M1c and report it to C. This is because daemon D1 is running in wildcard address in M1 for RPC communication.
4.This is the same scenario in local host condition also. Single daemon generate report for both source and destination for 2nd flow option.
5.When C asks for destination report in M2 for destination  M2a, then Daemon D2 generate reports of M2a, M2b, and M2c and report it to C1. The same scenario as explained in the step 3.

Bug:
1.Considering daemon and controller RPC URL connection string for M1a report as a comparison to ​​match exact report became irrelevant, because daemon D1 generating reports for M1b, M1c irrespective of request made to it to generate report for M1a only.
2.The present controller can't distinguish reports based on PRC URL connection string between daemon and controller. So in this case, controller fail to distinguish the reports.
3.The controller write invalid data in intermediate result and case segmentation fault in final report.

Fix:
​1.Best approach to this issue is that daemon giving it's own binding address along with other metrics​ report to controller, so that controller able to distinguish the reports based on it. But the problem also comes in this case.
2.For example, let us take this flow option for controller -F 0 -H s=M1a,d=M2a -F 1 -H s=M1a,d=M2b -F 2 s=M1a,d=M1c . All flows source address points to a single interface M1a. In this case, controller can't distinguish reports based on binding address alone. 
3.Here where, report ID and flow ID plays a vital role. Daemon running in wildcard address can't have same report ID for its interfaces in a single node. 
4.By comparing both daemon bind address and controller test address along with daemon report ID and controller flow ID resolve our bug in controller report_flow().

Implementation and changes in the code:
1.​​Added binding address data of daemon in report_flow() in daemon and retrieve the same data in controller fetch_reports().
2.Changed matching comparison in controller report_flow() to compare both daemon and controller binding address and report ID.
