### PR TITLE
Use designated initializers for array initialization

### DIFF
--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -732,7 +732,7 @@ static void prepare_grinding(xmlrpc_client *rpc_client)
 	log_output(headline);
 
 	/* prepare column visibility based on involved OSes */
-	bool involved_os[OS_LAST+1] = {};
+	bool involved_os[] = {[0 ... NUM_OSes-1] = false};
 	for (unsigned int j = 0; j < num_unique_servers; j++)
 		if (!strcmp(unique_servers[j].os_name, "Linux"))
 			involved_os[LINUX] = true;

--- a/src/flowgrind.h
+++ b/src/flowgrind.h
@@ -55,8 +55,8 @@ enum os {
 	FREEBSD,
 	/** Apple OS X. */
 	DARWIN,
-	/** Pointer to the last OS in the list. */
-	OS_LAST = DARWIN
+	/** Number of elements in enum. Must be last element. */
+	NUM_OSes
 };
 
 /** Unit of the TCP Stack. */


### PR DESCRIPTION
In addition, make magic number OS_LAST independent of other enum
members. If we add another OS in future, we do not need to change more
than one line of code.
