### PR TITLE
Fix the misleading examples for traffic generation

### DIFF
--- a/src/flowgrind.c
+++ b/src/flowgrind.c
@@ -418,12 +418,12 @@ static void usage_trafgenopt(void)
 		"               values over this cap are recalculated\n\n"
 
 		"Examples:\n"
-		"  -G s=q,C,40\n"
+		"  -G s=q:C:40\n"
 		"               use contant request size of 40 bytes\n"
-		"  -G s=p,N,2000,50\n"
+		"  -G s=p:N:2000:50\n"
 		"               use normal distributed response size with mean 2000 bytes and\n"
 		"               variance 50\n"
-		"  -G s=g,U,0.005,0.01\n"
+		"  -G s=g:U:0.005:0.01\n"
 		"               use uniform distributed interpacket gap with minimum 0.005s and\n"
 		"               maximum 0.01s\n\n"
 


### PR DESCRIPTION
This patch resolves the contradicting examples in `flowgrind --help=traffic` and therefore closes issue #188 
