### PR TITLE
To update the travis linux install for adding uuid library

### DIFF
--- a/scripts/travis.linux.install.deps.sh
+++ b/scripts/travis.linux.install.deps.sh
@@ -14,5 +14,5 @@ for PACKAGE in $PACKAGES; do
 done
 
 set -x
-sudo apt-get -qq install libxmlrpc-core-c3-dev libcurl4-gnutls-dev $EXTRA_PKGS
+sudo apt-get -qq install libxmlrpc-core-c3-dev libcurl4-gnutls-dev uuid-dev $EXTRA_PKGS
 


### PR DESCRIPTION
To add uuid-dev library in the Travis Linux install file
