### PR TITLE
flowgrindd: refactor connection establishment

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -244,13 +244,9 @@ static int prepare_rfds(struct timespec *now, struct flow *flow, fd_set *rfds)
 		DEBUG_MSG(LOG_ERR, "late connecting test socket for flow %d "
 			  "after %.3fs delay",
 			  flow->id, flow->settings.delay[WRITE]);
-		rc = connect(flow->fd, flow->addr, flow->addr_len);
-		if (rc == -1 && errno != EINPROGRESS) {
-			flow_error(flow, "Connect failed: %s", strerror(errno));
+		if (do_connect(flow) == -1) {
 			return -1;
 		}
-		flow->connect_called = 1;
-		flow->pmtu = get_pmtu(flow->fd);
 	}
 
 	/* Altough the server flow might be finished we keep the socket in

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -115,7 +115,7 @@ struct flow
 
 	unsigned congestion_counter;
 
-	/* Used for late_connect */
+	/* Used for do_connect for source flows */
 	struct sockaddr *addr;
 	socklen_t addr_len;
 

--- a/src/source.h
+++ b/src/source.h
@@ -33,5 +33,6 @@
 #endif /* HAVE_CONFIG_H */
 
 int add_flow_source(struct request_add_flow_source *request);
+int do_connect(struct flow *flow);
 
 #endif /* _SOURCE_H_ */


### PR DESCRIPTION
The do_connect flag of name2socket function and corresponding was never
used and connect() call in early connect case, did no error checking.

Fix that by introducing a do_connect() method, which is called
in early and late connect case.