### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flowgrind (0.8.1) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:09:06 +0100
+
 flowgrind (0.8.0) unstable; urgency=medium
 
   Release 0.8.0 (2016-09-19)

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Christian Samsel <christian.samsel@rwth-aachen.de>
 Build-Depends: debhelper (>= 7), autotools-dev, libxmlrpc-c3-dev | libxmlrpc-core-c3-dev, libcurl4-gnutls-dev | libcurl4-openssl-dev, libgsl0-dev, libpcap-dev, uuid-dev
 Standards-Version: 3.9.6
 Homepage: http://www.flowgrind.net
-Vcs-Git: git://github.com/flowgrind/flowgrind.git
+Vcs-Git: https://github.com/flowgrind/flowgrind.git
 Vcs-Browser: https://github.com/flowgrind/flowgrind
 
 Package: flowgrind


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
