### PR TITLE
daemon: Make daemon_thread, dump_prefix, dump_dir global

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -86,6 +86,10 @@
 
 int daemon_pipe[2];
 
+pthread_t daemon_thread;
+char *dump_prefix;
+char *dump_dir;
+
 pthread_mutex_t mutex;
 struct request *requests = 0, *requests_last = 0;
 

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -252,7 +252,7 @@ struct request_get_status
 	int num_flows;
 };
 
-pthread_t daemon_thread;
+extern pthread_t daemon_thread;
 
 /* Through this pipe we wakeup the thread from select */
 extern int daemon_pipe[2];
@@ -268,9 +268,8 @@ extern unsigned pending_reports;
  * large a reply can get */
 struct report* get_reports(int *has_more);
 
-/* FIXME: shouldn't be global? */
-char *dump_prefix;
-char *dump_dir;
+extern char *dump_prefix;
+extern char *dump_dir;
 
 void *daemon_main(void* ptr);
 void add_report(struct report* report);


### PR DESCRIPTION
With GCC 10 or when CFLAGS=-fno-common, building fails at the linker
stage because daemon_thread, dump_prefix, and dump_dir are incorrectly
declared in daemon.h and never defined explicitly.