### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 # Travis-CI build for flowgrind. See https://travis-ci.org for details.
 # Flowgrind also uses Coverity Scan. See https://scan.coverity.com/ for details.
-
 language:
     - c
 
 os:
     - linux
     - osx
+
+arch:
+    - amd64
+    - ppc64le
 
 compiler:
     - gcc
@@ -34,6 +37,8 @@ matrix:
         # Only check clang on OS X
         - os: osx
           compiler: gcc
+        - os: osx
+          arch: ppc64le
 
     include:
         # Covertiy scan should only run once


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/flowgrind/builds/189652947 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!